### PR TITLE
Fixed two issues within validateExpression (multiline comments and multiline statements)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
             "stopOnEntry": false,
             "sourceMaps": true,
-            "outFiles": ["${workspaceRoot}/out/src"],
+            "outFiles": ["${workspaceRoot}/out/src/**/*.js"],
             "preLaunchTask": "npm"
         },
         {


### PR DESCRIPTION
While browsing thru some Godot projects I discovered some issues with the validation of some correct GDScript statements. Because I had some trouble debugging the extension I fixed the `launch.json` file.

### Multiline comments
**Problem:** Within multiline comments the keywords like `if`, `for` etc. were treated as if they are normal code. So they produced validation errors like `':' expected at end of the line.`.
**Solution:* Now the beginning and the end of these regions are recognized and are not processed by the following keyword checks.

### Multiline statements
**Problem:** Multiline statements like described in issue #15 were not handled correct.
**Solution:** The beginning of a multiline statements, indicated by an ending backslash `if a = 10 and \` is recognized and processed until the statement ends with a colon `b = 20 :`. A missing backslash within a multiline statement of more than two lines is also recognized and leads to an `': or \' expected at end of the line.`

### Debugging configuration
`"outFiles": ["${workspaceRoot}/out/src/**/*.js"],`