### PR TITLE
Add project root configuration settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,11 @@
             "type": "boolean",
             "default": false,
             "description": "Show node pathes of of workspace in the code completion"
+        },
+        "GodotTools.godotProjectRoot": {
+            "type": "strng",
+            "default": "",
+            "description": "Relate path to the godot project"
         }
       }
     },

--- a/src/gdscript/definitionprovider.ts
+++ b/src/gdscript/definitionprovider.ts
@@ -23,8 +23,10 @@ class GDScriptDefinitionProivder implements DefinitionProvider {
         const getDefinitions = (content: string):Location[]| Location => {
             if(content.startsWith("res://")) {
                 content = content.replace("res://", "");
-                if(workspace && workspace.rootPath)
-                    content = path.join(workspace.rootPath, content)
+                if(workspace && workspace.rootPath) {
+                    var root = path.join(workspace.rootPath, workspace.getConfiguration("GodotTools").get("godotProjectRoot", ""));
+                    content = path.join(root, content);
+                }
                 return new Location(Uri.file(content), new Range(0,0,0,0));
             }
             else if(fs.existsSync(content) && fs.statSync(content).isFile()) {

--- a/src/gdscript/definitionprovider.ts
+++ b/src/gdscript/definitionprovider.ts
@@ -15,8 +15,10 @@ import config from '../config';
 import {isStr, getSelectedContent, getStrContent} from './utils';
 
 class GDScriptDefinitionProivder implements DefinitionProvider {
-    constructor() {
+    private _rootFolder : string = "";
 
+    constructor(rootFolder: string) {
+        this._rootFolder = rootFolder;
     }
 
     provideDefinition(document: TextDocument, position: Position, token: CancellationToken): Definition | Thenable < Definition > {
@@ -24,8 +26,7 @@ class GDScriptDefinitionProivder implements DefinitionProvider {
             if(content.startsWith("res://")) {
                 content = content.replace("res://", "");
                 if(workspace && workspace.rootPath) {
-                    var root = path.join(workspace.rootPath, workspace.getConfiguration("GodotTools").get("godotProjectRoot", ""));
-                    content = path.join(root, content);
+                    content = path.join(this._rootFolder, content);
                 }
                 return new Location(Uri.file(content), new Range(0,0,0,0));
             }

--- a/src/tool_manager.ts
+++ b/src/tool_manager.ts
@@ -117,7 +117,8 @@ class ToolManager {
                     const name = l.substring(0, l.indexOf("="));
 
                     let gdpath = l.substring(l.indexOf("res://") + "res://".length, l.indexOf(".gd") + ".gd".length);
-                    gdpath = path.join(self.workspaceDir, gdpath);
+                    let root = path.join(self.workspaceDir, vscode.workspace.getConfiguration("GodotTools").get("godotProjectRoot", ""))
+                    gdpath = path.join(root, gdpath);
                     let showgdpath = vscode.workspace.asRelativePath(gdpath);
 
                     let doc = "Auto loaded instance of " + `[${showgdpath}](${vscode.Uri.file(gdpath).toString()})`;


### PR DESCRIPTION
In some cases godot project can be in the separate folder of main project, I have added configuration parameter to handle this case.