### PR TITLE
single line if-else statement

### DIFF
--- a/src/gdscript/diagnostic.ts
+++ b/src/gdscript/diagnostic.ts
@@ -112,11 +112,8 @@ class GDScriptDiagnosticSeverity {
           return
         if(line.match(new RegExp(`.*?#.*?\\s${keywords[1]}\\s.*?`)))
           return
-        if(line.match(/.*?\sif\s+(\!|\[|\{|\w).*?\s+else\s+[^\s]+/))
+        if(line.match(/.*?\sif\s+(\!|\[|\{|\w|").*?\s+else\s+[^\s]+/))
           return
-        if(line.match(/.*?if.*else.*/)) {
-          return
-        }
         if (line.match(/.*?\\/))
           expectEndOfLine = true;
         else if (line.match(/.*?\:[\s+]+[^#\s]+/)) 

--- a/src/gdscript/diagnostic.ts
+++ b/src/gdscript/diagnostic.ts
@@ -114,6 +114,9 @@ class GDScriptDiagnosticSeverity {
           return
         if(line.match(/.*?\sif\s+(\!|\[|\{|\w).*?\s+else\s+[^\s]+/))
           return
+        if(line.match(/.*?if.*else.*/)) {
+          return
+        }
         if (line.match(/.*?\\/))
           expectEndOfLine = true;
         else if (line.match(/.*?\:[\s+]+[^#\s]+/)) 


### PR DESCRIPTION
This fixes the issue where single line if-else statements are diagnosed as an error:
```gdscript
variable = true if x == y else false
```
The regex(`.*?if.*else.*`) might be too broad though...