### PR TITLE
Close existing terminal when executing "run" commands

### DIFF
--- a/src/tool_manager.ts
+++ b/src/tool_manager.ts
@@ -196,7 +196,11 @@ class ToolManager {
     if (!fs.existsSync(editorPath) || !fs.statSync(editorPath).isFile()) {
       vscode.window.showErrorMessage("Invalid editor path to run the project");
     } else {
-      let terminal = vscode.window.createTerminal("Godot");
+      let existingTerminal = vscode.window.terminals.find(t => t._name === "GodotTools")
+      if (existingTerminal) {
+        existingTerminal.dispose()
+      }
+      let terminal = vscode.window.createTerminal("GodotTools");
       editorPath = this.escapeCmd(editorPath);
       let cmmand = `${editorPath} ${params}`;
       terminal.sendText(cmmand, true);


### PR DESCRIPTION
I often find myself with multiple game windows when running projects using this extension.
I prefer Godot's editor behavior of closing the existing game windows before launching another instance.

This PR adds a simple check followed by `Terminal#dispose` if a terminal found with the same name as our extension ones is found. Terminals are renamed to a more specific "GodotTools" to avoid a very hypothetical conflict with another extension.

Cheers,