### PR TITLE
Add `class_name` keyword to syntax highlighting

### DIFF
--- a/configurations/GDScript.full.tmLanguage.json
+++ b/configurations/GDScript.full.tmLanguage.json
@@ -9,9 +9,9 @@
     { "include": "#numbers" },
     { "include": "#self" },
     {
-      "captures": 
+      "captures":
       {
-        "1": 
+        "1":
         {
           "name": "punctuation.definition.comment.number-sign.gdscript"
         }
@@ -40,7 +40,7 @@
       "name": "keyword.operator.assignment.gdscript"
     },
     {
-      "match": "\\b(?i:class|extends|assert|signal)\\b",
+      "match": "\\b(?i:class|extends|class_name|assert|signal)\\b",
       "name": "keyword.other.gdscript"
     },
     {

--- a/configurations/GDScript.tmLanguage.json
+++ b/configurations/GDScript.tmLanguage.json
@@ -96,7 +96,7 @@
     },
 
     "keywords": {
-      "match": "\\b(?i:elif|else|for|if|while|break|continue|pass|in|is|return|onready|setget|enum|match|breakpoint|tool|extends|signal|class)\\b",
+      "match": "\\b(?i:elif|else|for|if|while|break|continue|pass|in|is|return|onready|setget|enum|match|breakpoint|tool|extends|class_name|signal|class)\\b",
       "name": "keyword.control.gdscript"
     },
     "letter": {


### PR DESCRIPTION
This adds the `class_name` keyword that was added to Godot 3.1.

PS: What's the difference between `GDScript.full.tmLanguage.json` and `GDScript.tmLanguage.json`? Are these used in different contexts?