### PR TITLE
Add fallback for shell var

### DIFF
--- a/src/tool_manager.ts
+++ b/src/tool_manager.ts
@@ -269,7 +269,7 @@ class ToolManager {
       let cmdEsc = `"${cmd}"`;
 
       // Fetch Windows shell type
-      let shell = vscode.workspace.getConfiguration("terminal.integrated.shell").get("windows", "");
+      let shell = vscode.workspace.getConfiguration("terminal.integrated.shell").get("windows", "") || "";
 
       // For powershell we prepend an & to prevent the command being treated as a string
       if (shell.endsWith("powershell.exe") && process.platform === "win32") {


### PR DESCRIPTION
Plugin doesn't seem to work on any of my linux machines. This shell var seems to be null on linux. Seems like it might be the case on MacOS too. When its null the console reports a lack of `endsWith` method on the null var. I am adding a fallback for the shell var that is an empty string. I am not sure if this is the best way to fix. But it does the trick for me.
 