### PR TITLE
Fix operator syntax highlighting when next to an opening parenthesis

### DIFF
--- a/syntaxes/GDScript.tmLanguage.json
+++ b/syntaxes/GDScript.tmLanguage.json
@@ -221,6 +221,9 @@
                     "include": "#keywords"
                 },
                 {
+                    "include": "#logic_op"
+                },
+                {
                     "include": "#control_flow"
                 },
                 {
@@ -685,9 +688,6 @@
                 },
                 {
                     "include": "#builtin_classes"
-                },
-                {
-                    "include": "#logic_op"
                 },
                 {
                     "comment": "Some color schemas support meta.function-call.generic scope",


### PR DESCRIPTION
This PR fixes the highlighting of the logic operators "or," "not," and "and" when used next to opening parenthesis.

Before:
![image](https://user-images.githubusercontent.com/31112680/171727254-c74d4460-e23f-4cda-806c-af93dacec0ed.png)

After:
![image](https://user-images.githubusercontent.com/31112680/171727301-933a9cc5-2bec-4c6e-86c3-3bfe135fd5ec.png)

This is related to #353.
