### PR TITLE
Add setting to override project directory location

### DIFF
--- a/package.json
+++ b/package.json
@@ -375,6 +375,11 @@
 					"type": "boolean",
 					"default": true,
 					"description": "Whether to enable inlay hints in GDResource (.tscn, .tres, etc) files"
+				},
+				"godotTools.workspace.overrideProjectDir": {
+					"type": "string",
+					"default": "",
+					"description": "Absolute path to a directory with a project.godot file. If set, this will override the auto-detected project directory."
 				}
 			}
 		},

--- a/src/utils/vscode_utils.ts
+++ b/src/utils/vscode_utils.ts
@@ -11,6 +11,15 @@ export function get_configuration(name: string, defaultValue?: any) {
 	return configValue;
 }
 
+export function get_configuration_with_scope(name: string, scope: vscode.ConfigurationScope, defaultValue?: any) {
+	const configValue = vscode.workspace.getConfiguration(EXTENSION_PREFIX, scope).get(name, null);
+	if (defaultValue && configValue === null) {
+		return defaultValue;
+	}
+	return configValue;
+}
+
+
 export function set_configuration(name: string, value: any) {
 	return vscode.workspace.getConfiguration(EXTENSION_PREFIX).update(name, value);
 }


### PR DESCRIPTION
The plugin currently provides no means of overriding the project directory location; it currently uses the first directory that contains `project.godot` that it finds. This means that if you're in a workspace with multiple `project.godot`s in various subdirectories, your only recourse is to either re-open the workspace scoped to that folder, or just delete those files.

This PR provides the setting `godotTools.workspace.overrideProjectDir`. Now when we search for the project dir, we check the setting with the scope of the current workspace directory (and every subsequent workspace directory if not found), and if we find `project.godot` using that, we use that.