### PR TITLE
Recognize pascal-case identifiers that ends with 2 or more upper case letters as `pascal_case_class`

### DIFF
--- a/syntaxes/GDScript.tmLanguage.json
+++ b/syntaxes/GDScript.tmLanguage.json
@@ -454,7 +454,7 @@
 			"name": "variable.other.constant.gdscript"
 		},
 		"pascal_case_class": {
-			"match": "\\b([A-Z]+[a-z_0-9]*([A-Z]?[a-z_0-9]+)*[A-Z]?)\\b",
+			"match": "\\b[A-Z]+(?:[a-z]+[A-Za-z0-9_]*)+\\b",
 			"name": "entity.name.type.class.gdscript"
 		},
 		"signal_declaration_bare": {


### PR DESCRIPTION
Fixes #907 

Before:

<img src="https://github.com/user-attachments/assets/1c01e752-2183-4ac5-ad67-03bdc129a8d0" />

After:

<img src="https://github.com/user-attachments/assets/64c7b97c-2823-44dd-a33f-2c3eb34f3798" />
