### PR TITLE
textmate rules: reclassify true/false/null as literal constants 

### DIFF
--- a/src/formatter/textmate.ts
+++ b/src/formatter/textmate.ts
@@ -113,7 +113,7 @@ function parse_token(token: Token) {
 		token.type = "keyword";
 		return;
 	}
-	if (token.scopes.includes("constant.language.gdscript")) {
+	if (token.scopes.includes("constant.language.gdscript") || token.scopes.includes("constant.language.literal.gdscript")) {
 		token.type = "constant";
 		return;
 	}

--- a/syntaxes/GDScript.tmLanguage.json
+++ b/syntaxes/GDScript.tmLanguage.json
@@ -250,7 +250,7 @@
 		},
 		"letter": {
 			"match": "\\b(?:true|false|null)\\b",
-            "name": "keyword.language.gdscript constant.language.gdscript"
+            "name": "constant.language.literal.gdscript"
 		},
 		"numbers": {
 			"patterns": [

--- a/syntaxes/GDScript.tmLanguage.json
+++ b/syntaxes/GDScript.tmLanguage.json
@@ -250,7 +250,7 @@
 		},
 		"letter": {
 			"match": "\\b(?:true|false|null)\\b",
-			"name": "constant.language.gdscript"
+            "name": "keyword.language.gdscript constant.language.gdscript"
 		},
 		"numbers": {
 			"patterns": [


### PR DESCRIPTION
This branch marks the `true`/`false`/`null` consts as language literal constants to mimic the behavior of the engine editor which treats them as such.

Before: both `true`/`false` and `Vector2.RIGHT` treated as same level
<img width="483" height="199" alt="image" src="https://github.com/user-attachments/assets/4ac3f64a-d4d6-4483-b05d-27ebe274d272" />

After: booleans are in a separate scope (correct behavior)
<img width="409" height="187" alt="image" src="https://github.com/user-attachments/assets/b12c1f98-7533-4991-b9a5-ce36500ebd6b" />
