### PR TITLE
Replace window reload with restart extension host

### DIFF
--- a/src/utils/prompts.ts
+++ b/src/utils/prompts.ts
@@ -5,7 +5,7 @@ export function prompt_for_reload() {
 	const message = "Reload VSCode to apply settings";
 	vscode.window.showErrorMessage(message, "Reload").then(item => {
 		if (item === "Reload") {
-			vscode.commands.executeCommand("workbench.action.reloadWindow");
+			vscode.commands.executeCommand("workbench.action.restartExtensionHost");
 		}
 	});
 }


### PR DESCRIPTION
UI can stay, this is just a faster way to reload extensions without losing unsaved data and has been available for at least 1-2 years in vscode now.

You can try out what this does in the command palette: Ctrl-Shift-P -> Restart Extension Host