### PR TITLE
Prevent double emission of `disconnect`

### DIFF
--- a/src/lsp/MessageIO.ts
+++ b/src/lsp/MessageIO.ts
@@ -51,10 +51,8 @@ export class MessageIO extends EventEmitter {
 			socket.on("data", (chunk: Buffer) => {
 				this.emit("data", chunk);
 			});
-			// socket.on("end", this.on_disconnected.bind(this));
 			socket.on("error", () => {
 				this.socket = null;
-				this.emit("disconnected");
 			});
 			socket.on("close", () => {
 				this.socket = null;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-vscode-plugin/issues/966

https://www.w3schools.com/nodejs/ref_socket.asp seems to be the best reference of socket I could fine.

For "error":

> Emitted when an error occurs. The 'close' event will be emitted directly after this event.

So for a socket that had an error (like not being able to connect) we would emit `disconnect` twice. This messed up the port fallback logic by trying to both create a new socket on the original wrong port and reconnecting the existing socket to the correct port.