### PR TITLE
Fix error when opening docs with unsupported symbols (#971)

### DIFF
--- a/src/providers/documentation_builder.ts
+++ b/src/providers/documentation_builder.ts
@@ -236,6 +236,9 @@ export function make_symbol_document(symbol: GodotNativeSymbol): string {
 		if (symbol.children) {
 			for (const s of symbol.children as GodotNativeSymbol[]) {
 				const elements = make_symbol_elements(s);
+				if (!elements) {
+					continue;
+				}
 				switch (s.kind) {
 					case SymbolKind.Property:
 					case SymbolKind.Variable:


### PR DESCRIPTION
Apparently Godot 4.6 docs contain some elements with `SymbolKind` currently unsupported.
I'm not sure why those weren't a problem in previous versions 🤔

I guess it would be cleaner to add support for those elements but imo not showing unsupported sections is fine (instead of erroring).

Resolves #971