### PR TITLE
ci fix (node version upgrade)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v5.0.0
         with:
-          node-version: 16.x
+          node-version: 22.x
 
       - name: Install dependencies
         run: npm install


### PR DESCRIPTION
this PR fixes https://github.com/godotengine/godot-vscode-plugin/actions/workflows/ci.yml by upgrading node-version which supports ReadableStream

```
> vsce package --out godot-tools.vsix

/home/runner/work/godot-vscode-plugin/godot-vscode-plugin/node_modules/undici/lib/web/webidl/index.js:530
webidl.is.ReadableStream = webidl.util.MakeTypeAssertion(ReadableStream)
                                                         ^

ReferenceError: ReadableStream is not defined
    at Object.<anonymous> (/home/runner/work/godot-vscode-plugin/godot-vscode-plugin/node_modules/undici/lib/web/webidl/index.js:530:58)
    at Module._compile (node:internal/modules/cjs/loader:1198:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1252:10)
    at Module.load (node:internal/modules/cjs/loader:1076:32)
    at Function.Module._load (node:internal/modules/cjs/loader:911:12)
    at Module.require (node:internal/modules/cjs/loader:1100:19)
    at require (node:internal/modules/cjs/helpers:119:18)
    at Object.<anonymous> (/home/runner/work/godot-vscode-plugin/godot-vscode-plugin/node_modules/undici/lib/web/fetch/util.js:12:20)
    at Module._compile (node:internal/modules/cjs/loader:1198:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1252:10)
Error: Process completed with exit code 1.
```