### PR TITLE
Fix wrong inlay hint positions in large documents

### DIFF
--- a/src/providers/inlay_hints.ts
+++ b/src/providers/inlay_hints.ts
@@ -98,6 +98,7 @@ export class GDInlayHintsProvider implements InlayHintsProvider {
 	async provideInlayHints(document: TextDocument, range: Range, token: CancellationToken): Promise<InlayHint[]> {
 		const hints: InlayHint[] = [];
 		const text = document.getText(range);
+		const textStartOffset = document.offsetAt(range.start);
 		log.debug("Inlay Hints: provideInlayHints");
 
 		if (document.fileName.endsWith(".gd")) {
@@ -137,7 +138,7 @@ export class GDInlayHintsProvider implements InlayHintsProvider {
 				}
 				// TODO: until godot supports nested document symbols, we need to send
 				// a hover request for each variable declaration that is nested
-				const start = document.positionAt(match.index + match[0].length - 1);
+				const start = document.positionAt(textStartOffset + match.index + match[0].length - 1);
 
 				if (hasDetail) {
 					const symbol = symbols.find((s) => s.name === match[3]);
@@ -148,7 +149,7 @@ export class GDInlayHintsProvider implements InlayHintsProvider {
 					}
 				}
 
-				const hoverPosition = document.positionAt(match.index + match[1].length);
+				const hoverPosition = document.positionAt(textStartOffset + match.index + match[1].length);
 				const detail = await addByHover(document, hoverPosition);
 				if (detail) {
 					const hint = this.buildHint(start, detail);
@@ -166,7 +167,7 @@ export class GDInlayHintsProvider implements InlayHintsProvider {
 
 		for (const match of text.matchAll(/ExtResource\(\s?"?(\w+)\s?"?\)/g)) {
 			const id = match[1];
-			const end = document.positionAt(match.index + match[0].length);
+			const end = document.positionAt(textStartOffset + match.index + match[0].length);
 			const resource = scene.externalResources.get(id);
 
 			const label = `${resource.type}: "${resource.path}"`;
@@ -178,7 +179,7 @@ export class GDInlayHintsProvider implements InlayHintsProvider {
 
 		for (const match of text.matchAll(/SubResource\(\s?"?(\w+)\s?"?\)/g)) {
 			const id = match[1];
-			const end = document.positionAt(match.index + match[0].length);
+			const end = document.positionAt(textStartOffset + match.index + match[0].length);
 			const resource = scene.subResources.get(id);
 
 			const label = `${resource.type}`;


### PR DESCRIPTION
Closes #980.

Fixes missing or misplaced inlay hints in GDScript and scene files, when scrolled down in a somewhat large document,

The extension respected the `range` parameter of `provideInlayHints` by extracting only that range substring for processing, but it didn't take the range into account when calculating positions for the LSP request or hint placement. So the position was incorrect any time the range start was non-zero.

The range is relative to vertical scroll position but with some padding. From my quick scan of the [relevant function in the VS Code source](https://github.com/microsoft/vscode/blob/072e99c1215d4acf06da82f9475d5a9b2fbc6e15/src/vs/editor/contrib/inlayHints/browser/inlayHintsController.ts#L460) the document size needed to reproduce should be something like two viewport heights tall plus 30 lines, so the bug is probably dependent on window and font size too :)

The linked issue has a repro GDScript (at least for me when fitting ~60 lines in the viewport). The bug also exists in scene files -- if you have a decent number of nodes with resources in the tree you'll find that the resource path hints are missing when scrolled down. I've attached a MRP with both a script and scene for testing convenience: [inlay-hints-test_2026-03-09_20-31-25.zip](https://github.com/user-attachments/files/25851822/inlay-hints-test_2026-03-09_20-31-25.zip)