### PR TITLE
Fix failing "Go to Definition" for some types

### DIFF
--- a/src/providers/documentation_builder.ts
+++ b/src/providers/documentation_builder.ts
@@ -4,9 +4,10 @@ import * as Prism from "prismjs";
 import * as csharp from "prismjs/components/prism-csharp";
 import { marked } from "marked";
 import type { GodotNativeSymbol } from "./documentation_types";
-import { get_extension_uri } from "../utils";
+import { createLogger, get_extension_uri } from "../utils";
 import yabbcode = require("ya-bbcode");
 
+const log = createLogger("providers.docs_builder");
 const parser = new yabbcode();
 
 //! I do not understand why this is necessary
@@ -120,6 +121,10 @@ export function make_html_content(webview: vscode.Webview, symbol: GodotNativeSy
 export function make_symbol_document(symbol: GodotNativeSymbol): string {
 	const classlink = make_link(symbol.native_class, undefined);
 
+	function make_symbol_id(name: string) {
+		return name.replace(/[^A-Za-z0-9_-]/g, "_");
+	}
+
 	function make_function_signature(s: GodotNativeSymbol, with_class = false) {
 		const parts = /\((.*)?\)\s*\-\>\s*(([A-z0-9]+)?)$/.exec(s.detail);
 		if (!parts) {
@@ -132,7 +137,7 @@ export function make_symbol_document(symbol: GodotNativeSymbol): string {
 		);
 		args = args.replace(/\s=\s(.*?)[\,\)]/g, "");
 		return `${ret_type} ${with_class ? `${classlink}.` : ""}${element("a", s.name, {
-			href: `#${s.name}`,
+			href: `#${make_symbol_id(s.name)}`,
 		})}( ${args} )`;
 	}
 
@@ -146,7 +151,7 @@ export function make_symbol_document(symbol: GodotNativeSymbol): string {
 					return;
 				}
 				const type = make_link(parts[2], undefined);
-				const name = element("a", s.name, { href: `#${s.name}` });
+				const name = element("a", s.name, { href: `#${make_symbol_id(s.name)}` });
 				const title = element("h4", `${type} ${with_class ? `${classlink}.` : ""}${s.name}`);
 				const doc = element("p", format_documentation(s.documentation, symbol.native_class));
 				const div = element("div", title + doc);
@@ -193,7 +198,9 @@ export function make_symbol_document(symbol: GodotNativeSymbol): string {
 				};
 			}
 			case SymbolKind.Method:
-			case SymbolKind.Function: {
+			case SymbolKind.Function:
+			case SymbolKind.Constructor:
+			case SymbolKind.Operator: {
 				const signature = make_function_signature(s, with_class);
 				const title = element("h4", signature);
 				const doc = element("p", format_documentation(s.documentation, symbol.native_class));
@@ -227,8 +234,12 @@ export function make_symbol_document(symbol: GodotNativeSymbol): string {
 
 		let constants = "";
 		let signals = "";
+		let constructors_index = "";
+		let constructors = "";
 		let methods_index = "";
 		let methods = "";
+		let operators_index = "";
+		let operators = "";
 		let properties_index = "";
 		let propertyies = "";
 		let others = "";
@@ -236,25 +247,38 @@ export function make_symbol_document(symbol: GodotNativeSymbol): string {
 		if (symbol.children) {
 			for (const s of symbol.children as GodotNativeSymbol[]) {
 				const elements = make_symbol_elements(s);
+				if (!elements) {
+					log.debug(`Unable to render symbol "${s.name}" (unhandled SymbolKind ${s.kind})`);
+					continue;
+				}
+				const id = make_symbol_id(s.name);
 				switch (s.kind) {
 					case SymbolKind.Property:
 					case SymbolKind.Variable:
 						properties_index += element("li", elements.index);
-						propertyies += element("li", elements.body, { id: s.name });
+						propertyies += element("li", elements.body, { id });
 						break;
 					case SymbolKind.Constant:
-						constants += element("li", elements.body, { id: s.name });
+						constants += element("li", elements.body, { id });
 						break;
 					case SymbolKind.Event:
-						signals += element("li", elements.body, { id: s.name });
+						signals += element("li", elements.body, { id });
+						break;
+					case SymbolKind.Constructor:
+						constructors_index += element("li", elements.index);
+						constructors += element("li", elements.body, { id });
 						break;
 					case SymbolKind.Method:
 					case SymbolKind.Function:
 						methods_index += element("li", elements.index);
-						methods += element("li", elements.body, { id: s.name });
+						methods += element("li", elements.body, { id });
+						break;
+					case SymbolKind.Operator:
+						operators_index += element("li", elements.index);
+						operators += element("li", elements.body, { id });
 						break;
 					default:
-						others += element("li", elements.body, { id: s.name });
+						others += element("li", elements.body, { id });
 						break;
 				}
 			}
@@ -268,11 +292,15 @@ export function make_symbol_document(symbol: GodotNativeSymbol): string {
 		};
 
 		add_group("Properties", properties_index);
-		add_group("Constants", constants);
-		add_group("Signals", signals);
+		add_group("Constructors", constructors_index);
 		add_group("Methods", methods_index);
+		add_group("Operators", operators_index);
+		add_group("Signals", signals);
+		add_group("Constants", constants);
 		add_group("Property Descriptions", propertyies);
+		add_group("Constructor Descriptions", constructors);
 		add_group("Method Descriptions", methods);
+		add_group("Operator Descriptions", operators);
 		add_group("Other Members", others);
 		doc += element("script", `var godot_class = "${symbol.native_class}";`);
 


### PR DESCRIPTION
Fixes #924

As explained in #924, "Go to Definition" doesn't work for some types.

There are three different problems described in that issue.

## First problem

"Go to Definition" doesn't work for types with constructors and/or operators (like [String](https://docs.godotengine.org/en/stable/classes/class_string.html#string) or [Vector2i](https://docs.godotengine.org/en/stable/classes/class_vector2i.html#vector2i)).

**This PR is a full fix only for this.** Now those types get their documentation properly generated.

I also added a safeguard for the future: in case the LSP surfaces other properties not handled by this extension, the extension will still generate the documentation it can while printing the problem of unhandled property types to the debug log.

## Second problem

"Go to Definition" doesn't work for types with properties containing multiple forward slashes (`/`) in their names, like [ProjectSettings](https://docs.godotengine.org/en/stable/classes/class_projectsettings.html#projectsettings).

This is **partially** fixed in this PR too: the documentation for `ProjectSettings` opens, but it's missing a bunch of properties. 

This happens because of this: https://github.com/godotengine/godot-vscode-plugin/blob/e99adb032618e4199672fdc0a2a29d8bcf68fe39/src/providers/documentation_builder.ts#L144

`ProjectSettings` has hundreds of properties with `/` in their names (e.g., `application/boot_splash/bg_color`, `display/window/size/viewport_width`). These come from the engine's [ProjectSettings.xml](https://github.com/godotengine/godot/blob/master/doc/classes/ProjectSettings.xml) doc file, where each engine setting is documented as a class member. The LSP produces detail strings like:
```
var ProjectSettings.application/boot_splash/bg_color: Color
```

The regex character class `[A-z_0-9]` does **not** match `/` (ASCII 47 is outside the `A`=65 to `z`=122 range). So `parts` is `null`, the function returns `undefined`, and the caller crashes on `elements.index` (line 242) with a similar TypeError.

After this PR is merged, I'll open a separate issue to track this.

## Third problem

In the second half of [this comment](https://github.com/godotengine/godot-vscode-plugin/issues/924#issuecomment-4016945128), I brought up a problem with navigation to `TileMapLayer`'s methods. This bug is completely unrelated to the other two. I'll open a separate issue in the engine's repo to track that too.