### PR TITLE
Update README.md to add instructions for XWayland workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ Godot has some Editor Settings that can help you if your workflow involves chang
 
 ### I'm using Linux and the drag + shift drop isn't working. Why?
 
-Most likely you're using Wayland as display server, and there's a limitation of support in VS Code. Try
-running `code` through the terminal in the project directory with the flag `--ozone-platform=x11`.
-This will force VS Code to run through XWayland, where it works.
+Most likely you're using Wayland as display server, and there's a limitation of support in VS Code. 
+In the exec flags, modify the snippet from `{project} --goto {file}:{line}:{col}` to 
+`{project} --goto {file}:{line}:{col} --ozone-platform=x11`, which will force VS Code to run
+through XWayland, where it works.


### PR DESCRIPTION
I discovered recently that you can put the --ozone-platform=x11 snippet in the Exec Flags, and it'll also force to run VS Code through XWayland, without having to run it through the terminal. This facilitates a lot, so the user don't have to manually navigate to the folder of the project and running code with the flag.