### PR TITLE
GDScript: Add abstract functions to highlight grammar

### DIFF
--- a/syntaxes/GDScript.tmLanguage.json
+++ b/syntaxes/GDScript.tmLanguage.json
@@ -366,10 +366,11 @@
 			}
 		},
 		"class_is": {
-			"match": "\\s+(is)\\s+([a-zA-Z_]\\w*)",
+			"match": "\\s+(is)\\s+(not?)\\s+\\s+([a-zA-Z_]\\w*)",
 			"captures": {
 				"1": { "name": "storage.type.is.gdscript" },
-				"2": { "name": "entity.name.type.class.gdscript" }
+				"2": { "name": "storage.type.not.gdscript" },
+				"3": { "name": "entity.name.type.class.gdscript" }
 			}
 		},
 		"class_enum": {
@@ -507,7 +508,7 @@
 				"1": { "name": "keyword.language.gdscript storage.type.function.gdscript" },
 				"2": { "name": "entity.name.function.gdscript" }
 			},
-			"end": "(:)",
+			"end": "(:)|\n",
 			"endCaptures": { "1": { "name": "punctuation.section.function.begin.gdscript" } },
 			"patterns": [
 				{ "include": "#parameters" },


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot-vscode-plugin/issues/962

Also adds `is not` (although not sure on the role, but it looks fine with the default color scheme)
Fixes: https://github.com/godotengine/godot-vscode-plugin/issues/834