### PR TITLE
Add gdscript highlight in markdown code block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Unreleased
+
+- [Add GDScript syntax highlighting inside Markdown fenced code blocks](https://github.com/godotengine/godot-vscode-plugin/pull/1022)
+
 ### 2.6.1
 
 - [Fix broken LSP connection handshake, which resulted in VS Code constantly trying to reconnect](https://github.com/godotengine/godot-vscode-plugin/pull/968)

--- a/package.json
+++ b/package.json
@@ -435,6 +435,16 @@
 				"path": "./syntaxes/GDScript.tmLanguage.json"
 			},
 			{
+				"scopeName": "markdown.gdscript.codeblock",
+				"path": "./syntaxes/GDScriptMarkdown.tmLanguage.json",
+				"injectTo": [
+					"text.html.markdown"
+				],
+				"embeddedLanguages": {
+					"meta.embedded.block.gdscript": "gdscript"
+				}
+			},
+			{
 				"language": "gdresource",
 				"scopeName": "source.gdresource",
 				"path": "./syntaxes/GDResource.tmLanguage.json"

--- a/syntaxes/GDScriptMarkdown.tmLanguage.json
+++ b/syntaxes/GDScriptMarkdown.tmLanguage.json
@@ -1,0 +1,34 @@
+{
+	"fileTypes": [],
+	"scopeName": "markdown.gdscript.codeblock",
+	"name": "GDScript Markdown Code Block",
+	"injectionSelector": "L:text.html.markdown",
+	"patterns": [
+		{ "include": "#gdscript-code-block" }
+	],
+	"repository": {
+		"gdscript-code-block": {
+			"begin": "(^|\\G)(\\s*)(`{3,}|~{3,})\\s*(?i:(gdscript)(\\s+[^`~]*)?$)",
+			"name": "markup.fenced_code.block.markdown",
+			"end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+			"beginCaptures": {
+				"3": { "name": "punctuation.definition.markdown" },
+				"4": { "name": "fenced_code.block.language.markdown" },
+				"5": { "name": "fenced_code.block.language.attributes.markdown" }
+			},
+			"endCaptures": {
+				"3": { "name": "punctuation.definition.markdown" }
+			},
+			"patterns": [
+				{
+					"begin": "(^|\\G)(\\s*)(.*)",
+					"while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+					"contentName": "meta.embedded.block.gdscript",
+					"patterns": [
+						{ "include": "source.gdscript" }
+					]
+				}
+			]
+		}
+	}
+}

--- a/syntaxes/examples/gdscript-markdown.md
+++ b/syntaxes/examples/gdscript-markdown.md
@@ -1,0 +1,16 @@
+# GDScript Markdown Fences
+
+```gdscript
+extends Node
+
+func _ready() -> void:
+	print("Hello from gdscript")
+```
+
+```GDScript
+class_name Player
+extends CharacterBody2D
+
+func move(delta: float) -> void:
+	velocity.x = 100.0 * delta
+```


### PR DESCRIPTION
Add grammar to highlight gd script in markdown.

The main use case I have is let claude/codex generate me a tutorial doc so that I can
follow it and write the scripts by myself instead of vibe everything.

<img width="843" height="610" alt="markdown-gdscript" src="https://github.com/user-attachments/assets/f97ea2dd-806d-4aef-826e-c6a491d5e062" />
