### PR TITLE
Fix LSP disconnect when opening project subfolder

### DIFF
--- a/src/lsp/GDScriptLanguageClient.ts
+++ b/src/lsp/GDScriptLanguageClient.ts
@@ -267,8 +267,15 @@ export default class GDScriptLanguageClient extends LanguageClient {
 
 	private async check_workspace(message: ChangeWorkspaceNotification) {
 		const server_path = path.normalize(message.params.path);
-		const client_path = path.normalize(await get_project_dir() ?? "");
-		if (server_path !== client_path) {
+		const client_path = path.normalize((await get_project_dir()) ?? "");
+
+		// Allow the client workspace to be a subfolder of the server's project.
+		// The LSP server reports the real project root (where project.godot lives),
+		// but the user may have opened a subfolder of the project in VS Code.
+		const is_subfolder = client_path.startsWith(server_path + path.sep);
+		const is_same = client_path === server_path;
+
+		if (!is_same && !is_subfolder) {
 			log.warn("Connected LSP is a different workspace");
 			this.io.socket?.resetAndDestroy();
 			this.rejected = true;

--- a/src/utils/godot_utils.ts
+++ b/src/utils/godot_utils.ts
@@ -27,9 +27,6 @@ export async function get_project_dir(): Promise<string | undefined> {
 	if (vscode.workspace.workspaceFolders !== undefined) {
 		const files = await vscode.workspace.findFiles("**/project.godot", null);
 
-		if (files.length === 0) {
-			return undefined;
-		}
 		if (files.length === 1) {
 			file = files[0].fsPath;
 			if (!fs.existsSync(file) || !fs.statSync(file).isFile()) {
@@ -44,7 +41,17 @@ export async function get_project_dir(): Promise<string | undefined> {
 					return undefined;
 				}
 			}
+		} else {
+			// No project.godot found in workspace — walk up from workspace folder
+			const workspacePath = vscode.workspace.workspaceFolders[0].uri.fsPath;
+			const found = find_project_file(workspacePath);
+			if (found) {
+				file = found;
+			}
 		}
+	}
+	if (!file) {
+		return undefined;
 	}
 	projectFile = file;
 	projectDir = path.dirname(file);


### PR DESCRIPTION
## Summary

Fixes #1025.

When a user opens a subfolder of a Godot project (e.g. scripts/), the LSP connection would immediately disconnect because get_project_dir() couldn't find project.godot (it only searched within the workspace folder), causing the workspace mismatch check to fail.

### Changes

**src/utils/godot_utils.ts** — get_project_dir() now falls back to walking up the directory tree from the workspace folder using the existing ind_project_file() helper when indFiles() finds nothing in the workspace.

**src/lsp/GDScriptLanguageClient.ts** — check_workspace() now allows the client workspace to be a subfolder of the server's reported project root, instead of requiring an exact path match. A genuine mismatch (client workspace is not inside the server's project) still triggers disconnect.

### Notes

The Godot LSP server intentionally sends a workspace mismatch notification when the client workspace doesn't match the project root. The server dev (HolonProduction) confirmed this is intended behavior — the server won't support subfolders as workspace. This change makes the extension handle the mismatch gracefully by accepting subfolders rather than disconnecting.