### PR TITLE
CI: Update fgvm calls to use `which` in order to resolve the path.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Cache Godot installations
         uses: actions/cache@v4
         with:
-          path: ${{ runner.temp }}/fgvm/fgvm/installations
+          path: ${{ runner.temp }}/fgvm/installations
           key: fgvm-${{ matrix.os }}-${{ matrix.godot_version }}
 
       - name: Install Godot ${{ matrix.godot_version }}

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ workspace.code-workspace
 *.tmp
 lode/
 test_projects/*/.vscode/settings.json
+.idea

--- a/tools/resolve_godot.ts
+++ b/tools/resolve_godot.ts
@@ -1,113 +1,21 @@
-import * as fs from "node:fs";
-import * as path from "node:path";
-import * as os from "node:os";
+import { execFileSync } from "node:child_process";
 
 /**
  * Resolves the path to a fgvm-managed Godot executable for a given version.
  *
- * fgvm stores installations under:
- *   <fgvm-home>/installations/<version-name>/<platform-dir>/<executable>
- *
- * <fgvm-home> is $FGVM_HOME/fgvm if FGVM_HOME is set (fgvm creates a "fgvm"
- * subdirectory inside the specified path), or ~/fgvm by default.
- *
- * Example on Windows:
- *   ~/fgvm/installations/4.7-stable-standard/win64.exe/Godot_v4.7-stable_win64.exe
- *
- * The version query ("4.7", "3.6.2") is matched against the installation dir name
- * with a "-stable-" suffix to avoid matching pre-release builds.
- */
-
-function get_fgvm_home(): string {
-	const env = process.env.FGVM_HOME;
-	if (env) {
-		// fgvm creates a "fgvm" subdirectory inside FGVM_HOME
-		return path.join(env, "fgvm");
-	}
-	return path.join(os.homedir(), "fgvm");
-}
-
-/**
- * The platform-specific subdirectory and executable glob pattern.
- * fgvm uses different directory names and executable patterns per OS.
- */
-function get_platform_pattern(): { dir: string; glob: string } {
-	const platform = process.platform;
-	const arch = process.arch;
-
-	if (platform === "win32" && arch === "x64") {
-		return { dir: "win64.exe", glob: "Godot_v*_win64.exe" };
-	}
-	if (platform === "darwin" && arch === "arm64") {
-		return { dir: "osx.arm64", glob: "Godot_v*osx.universal" };
-	}
-	if (platform === "darwin" && arch === "x64") {
-		return { dir: "osx.x86_64", glob: "Godot_v*osx.universal" };
-	}
-	if (platform === "linux" && arch === "x64") {
-		return { dir: "linux.x86_64", glob: "Godot_v*_linux.x86_64" };
-	}
-	if (platform === "linux" && arch === "arm64") {
-		return { dir: "linux.arm64", glob: "Godot_v*_linux.arm64" };
-	}
-
-	throw new Error(`Unsupported platform: ${platform}-${arch}`);
-}
-
-/**
- * Find a fgvm-managed Godot executable by version.
- *
  * @param version Version query, e.g. "4.7", "3.6.2"
  * @returns Absolute path to the Godot executable
- * @throws If no matching installation is found
+ * @throws If fgvm cannot resolve the requested version
  */
 export function resolve_godot_binary(version: string): string {
-	const home = get_fgvm_home();
-	const installationsDir = path.join(home, "installations");
+	const binaryPath = execFileSync("fgvm", ["which", version], {
+		encoding: "utf8",
+		env: process.env,
+	}).trim();
 
-	if (!fs.existsSync(installationsDir)) {
-		throw new Error(`fgvm installations directory not found: ${installationsDir}`);
+	if (!binaryPath) {
+		throw new Error(`fgvm returned no executable path for version "${version}"`);
 	}
 
-	// Match version against installation dir names.
-	// fgvm names: "4.7-stable-standard", "3.6.2-stable-standard", etc.
-	// We match "<version>-stable-*" to avoid pre-release builds.
-	const prefix = `${version}-stable-`;
-
-	const candidates = fs
-		.readdirSync(installationsDir)
-		.filter((name) => name.startsWith(prefix));
-
-	if (candidates.length === 0) {
-		throw new Error(
-			`No fgvm installation found for version "${version}". ` +
-				`Run: fgvm install ${version}`,
-		);
-	}
-
-	if (candidates.length > 1) {
-		throw new Error(
-			`Multiple installations found for version "${version}": ${candidates.join(", ")}`,
-		);
-	}
-
-	const installDir = path.join(installationsDir, candidates[0]);
-	const { dir: platformDir, glob } = get_platform_pattern();
-	const platformPath = path.join(installDir, platformDir);
-
-	if (!fs.existsSync(platformPath)) {
-		throw new Error(`Platform directory not found: ${platformPath}`);
-	}
-
-	// Find the Godot executable (exclude console/debug variants on Windows)
-	const executables = fs
-		.readdirSync(platformPath)
-		.filter((f) => f.match(/^Godot_v.*(_win64\.exe|osx\.universal|linux\.x86_64|linux\.arm64)$/))
-		.filter((f) => !f.includes("_console."));
-
-	if (executables.length === 0) {
-		throw new Error(`No Godot executable found in ${platformPath}`);
-	}
-
-	return path.join(platformPath, executables[0]);
+	return binaryPath;
 }

--- a/tools/run_tests.ts
+++ b/tools/run_tests.ts
@@ -10,7 +10,8 @@
  *   ts-node tools/run_tests.ts 4.7 "typed dict"             # Only matching tests
  *   ts-node tools/run_tests.ts 3.6.2 --godot3               # Test against Godot 3.6.2
  *
- * Resolves the Godot binary from fgvm's installation directory,
+ * Resolves the Godot binary through fgvm's `which` command, which honors
+ * FGVM_HOME as fgvm's root (or ~/fgvm when FGVM_HOME is unset),
  * writes a .vscode/settings.json into the test project with the
  * correct editorPath, then runs the existing vscode-test setup.
  */


### PR DESCRIPTION
Hi,

I'm the maintainer of [fgvm](https://github.com/patricktcoakley/fgvm), which is being used in the CI. I noticed an issue with some failed runs where it couldn't find the path, and wanted to offer a better way to resolve the path using the `which` command, which I recently updated a few weeks ago to take a query that filters it to the closes installation and only prints the path. The FGVM_HOME path was mostly used for testing purposes and I ended up making a breaking change that effects the current resolver code, but using `which` solves that in a cleaner manner.