### PR TITLE
Improvements: Added ① blank line clearing and ② control flow statement formatting features with their configurations.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ workspace.code-workspace
 *.tmp
 lode/
 test_projects/*/.vscode/settings.json
+desktop.ini

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,21 +20,22 @@
 				"terminate": "^2.5.0",
 				"vscode-languageclient": "^9.0.1",
 				"vscode-oniguruma": "^2.0.1",
-				"vscode-textmate": "^9.0.0",
+				"vscode-textmate": "^9.3.2",
 				"ws": "^8.17.1",
 				"ya-bbcode": "^4.0.0"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "^1.9.4",
-				"@types/chai": "^4.3.11",
+				"@types/chai": "^4.3.20",
 				"@types/chai-as-promised": "^8.0.1",
 				"@types/chai-subset": "^1.3.5",
+				"@types/jest": "^30.0.0",
 				"@types/marked": "^4.0.8",
-				"@types/mocha": "^10.0.6",
-				"@types/node": "^18.19.75",
+				"@types/mocha": "^10.0.10",
+				"@types/node": "^18.19.130",
 				"@types/prismjs": "^1.16.8",
 				"@types/sinon": "^17.0.4",
-				"@types/vscode": "^1.96.0",
+				"@types/vscode": "^1.125.0",
 				"@types/ws": "^8.5.4",
 				"@typescript-eslint/eslint-plugin": "^5.57.1",
 				"@typescript-eslint/eslint-plugin-tslint": "^5.57.1",
@@ -153,9 +154,9 @@
 			}
 		},
 		"node_modules/@azure/identity": {
-			"version": "4.13.0",
-			"resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.13.0.tgz",
-			"integrity": "sha512-uWC0fssc+hs1TGGVkkghiaFkkS7NkTxfnCH+Hdg+yTehTpMcehpok4PgUKKdyCH+9ldu6FhiHRv84Ntqj1vVcw==",
+			"version": "4.13.1",
+			"resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.13.1.tgz",
+			"integrity": "sha512-5C/2WD5Vb1lHnZS16dNQRPMjN6oV/Upba+C9nBIs15PmOi6A3ZGs4Lr2u60zw4S04gi+u3cEXiqTVP7M4Pz3kw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -166,8 +167,8 @@
 				"@azure/core-tracing": "^1.0.0",
 				"@azure/core-util": "^1.11.0",
 				"@azure/logger": "^1.0.0",
-				"@azure/msal-browser": "^4.2.0",
-				"@azure/msal-node": "^3.5.0",
+				"@azure/msal-browser": "^5.5.0",
+				"@azure/msal-node": "^5.1.0",
 				"open": "^10.1.0",
 				"tslib": "^2.2.0"
 			},
@@ -190,22 +191,22 @@
 			}
 		},
 		"node_modules/@azure/msal-browser": {
-			"version": "4.28.1",
-			"resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-4.28.1.tgz",
-			"integrity": "sha512-al2u2fTchbClq3L4C1NlqLm+vwKfhYCPtZN2LR/9xJVaQ4Mnrwf5vANvuyPSJHcGvw50UBmhuVmYUAhTEetTpA==",
+			"version": "5.17.1",
+			"resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.17.1.tgz",
+			"integrity": "sha512-zBhRGzABKSI7hfWh5EaZmril5ybZ7imBN1qEZl5sDTaelr+l8SnPjZO50Q4dnKnm347YPIlBMSnXKZyh3Yu5DQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@azure/msal-common": "15.14.1"
+				"@azure/msal-common": "16.11.2"
 			},
 			"engines": {
 				"node": ">=0.8.0"
 			}
 		},
 		"node_modules/@azure/msal-common": {
-			"version": "15.14.1",
-			"resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.14.1.tgz",
-			"integrity": "sha512-IkzF7Pywt6QKTS0kwdCv/XV8x8JXknZDvSjj/IccooxnP373T5jaadO3FnOrbWo3S0UqkfIDyZNTaQ/oAgRdXw==",
+			"version": "16.11.2",
+			"resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.11.2.tgz",
+			"integrity": "sha512-yDhtBOGDCdK9ipQ9g3+wmlMEPnZx2pXaDicDd9jYyR1L+7lEbvEohTDmF5qejZDutZY3m9pWPxeYxzNC701A2w==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -213,18 +214,17 @@
 			}
 		},
 		"node_modules/@azure/msal-node": {
-			"version": "3.8.6",
-			"resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-3.8.6.tgz",
-			"integrity": "sha512-XTmhdItcBckcVVTy65Xp+42xG4LX5GK+9AqAsXPXk4IqUNv+LyQo5TMwNjuFYBfAB2GTG9iSQGk+QLc03vhf3w==",
+			"version": "5.4.1",
+			"resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.4.1.tgz",
+			"integrity": "sha512-yqgoyOIMCH7TNaSLMBTP+4LUlbMMf1zgC8nzOFG95lmW82CmsAEtUT0J93e4BdqDcnX5qle/9X+yb7A8Mw9M0g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@azure/msal-common": "15.14.1",
-				"jsonwebtoken": "^9.0.0",
-				"uuid": "^8.3.0"
+				"@azure/msal-common": "16.11.2",
+				"jsonwebtoken": "^9.0.0"
 			},
 			"engines": {
-				"node": ">=16"
+				"node": ">=20"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -932,9 +932,9 @@
 			}
 		},
 		"node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.16",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -943,9 +943,9 @@
 			}
 		},
 		"node_modules/@eslint/eslintrc/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -982,9 +982,9 @@
 			}
 		},
 		"node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.16",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -993,9 +993,9 @@
 			}
 		},
 		"node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -1084,6 +1084,161 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/@jest/diff-sequences": {
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz",
+			"integrity": "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/expect-utils": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.4.1.tgz",
+			"integrity": "sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/get-type": "30.1.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/get-type": {
+			"version": "30.1.0",
+			"resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
+			"integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/pattern": {
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
+			"integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*",
+				"jest-regex-util": "30.4.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/schemas": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+			"integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@sinclair/typebox": "^0.34.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/types": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
+			"integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/pattern": "30.4.0",
+				"@jest/schemas": "30.4.1",
+				"@types/istanbul-lib-coverage": "^2.0.6",
+				"@types/istanbul-reports": "^3.0.4",
+				"@types/node": "*",
+				"@types/yargs": "^17.0.33",
+				"chalk": "^4.1.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/types/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/@jest/types/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/@jest/types/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/@jest/types/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@jest/types/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@jest/types/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/@jridgewell/resolve-uri": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -1160,6 +1315,13 @@
 			"engines": {
 				"node": ">=14"
 			}
+		},
+		"node_modules/@sinclair/typebox": {
+			"version": "0.34.52",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.52.tgz",
+			"integrity": "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@sinonjs/commons": {
 			"version": "3.0.1",
@@ -1271,6 +1433,37 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/istanbul-lib-report": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+			"integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/istanbul-lib-coverage": "*"
+			}
+		},
+		"node_modules/@types/istanbul-reports": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+			"integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/istanbul-lib-report": "*"
+			}
+		},
+		"node_modules/@types/jest": {
+			"version": "30.0.0",
+			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
+			"integrity": "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"expect": "^30.0.0",
+				"pretty-format": "^30.0.0"
+			}
+		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.15",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1333,10 +1526,17 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/stack-utils": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+			"integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/vscode": {
-			"version": "1.108.1",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.108.1.tgz",
-			"integrity": "sha512-DerV0BbSzt87TbrqmZ7lRDIYaMiqvP8tmJTzW2p49ZBVtGUnGAu2RGQd1Wv4XMzEVUpaHbsemVM5nfuQJj7H6w==",
+			"version": "1.125.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.125.0.tgz",
+			"integrity": "sha512-0icm/ZQAaism87P0ekHqi4/Ju9du+Tm0RUW+y7vqRsxY2cY0FNRX1nAnaW7nT6npPt2tfHiheZ55Zm9UhqonFA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -1349,6 +1549,23 @@
 			"dependencies": {
 				"@types/node": "*"
 			}
+		},
+		"node_modules/@types/yargs": {
+			"version": "17.0.35",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+			"integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/yargs-parser": "*"
+			}
+		},
+		"node_modules/@types/yargs-parser": {
+			"version": "21.0.3",
+			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+			"integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
 			"version": "5.62.0",
@@ -1833,9 +2050,9 @@
 			]
 		},
 		"node_modules/@vscode/vsce/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.16",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1866,9 +2083,9 @@
 			}
 		},
 		"node_modules/@vscode/vsce/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -1925,9 +2142,9 @@
 			}
 		},
 		"node_modules/ajv": {
-			"version": "6.12.6",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+			"integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2130,9 +2347,9 @@
 			"license": "ISC"
 		},
 		"node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+			"integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0"
@@ -2477,6 +2694,22 @@
 			"dev": true,
 			"license": "ISC",
 			"optional": true
+		},
+		"node_modules/ci-info": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+			"integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/sibiraj-s"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
 		},
 		"node_modules/cli-cursor": {
 			"version": "5.0.0",
@@ -3273,9 +3506,9 @@
 			}
 		},
 		"node_modules/eslint/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.16",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3384,9 +3617,9 @@
 			}
 		},
 		"node_modules/eslint/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3533,6 +3766,24 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/expect": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-30.4.1.tgz",
+			"integrity": "sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/expect-utils": "30.4.1",
+				"@jest/get-type": "30.1.0",
+				"jest-matcher-utils": "30.4.1",
+				"jest-message-util": "30.4.1",
+				"jest-mock": "30.4.1",
+				"jest-util": "30.4.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3660,9 +3911,9 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-			"integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+			"integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -3684,17 +3935,17 @@
 			}
 		},
 		"node_modules/form-data": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-			"integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+			"integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.8",
 				"es-set-tostringtag": "^2.1.0",
-				"hasown": "^2.0.2",
-				"mime-types": "^2.1.12"
+				"hasown": "^2.0.4",
+				"mime-types": "^2.1.35"
 			},
 			"engines": {
 				"node": ">= 6"
@@ -3974,9 +4225,9 @@
 			}
 		},
 		"node_modules/hasown": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+			"integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4444,6 +4695,433 @@
 				"@pkgjs/parseargs": "^0.11.0"
 			}
 		},
+		"node_modules/jest-diff": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.4.1.tgz",
+			"integrity": "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/diff-sequences": "30.4.0",
+				"@jest/get-type": "30.1.0",
+				"chalk": "^4.1.2",
+				"pretty-format": "30.4.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-diff/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/jest-diff/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/jest-diff/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/jest-diff/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/jest-diff/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/jest-diff/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/jest-matcher-utils": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.4.1.tgz",
+			"integrity": "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/get-type": "30.1.0",
+				"chalk": "^4.1.2",
+				"jest-diff": "30.4.1",
+				"pretty-format": "30.4.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-matcher-utils/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/jest-matcher-utils/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/jest-matcher-utils/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/jest-matcher-utils/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/jest-matcher-utils/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/jest-matcher-utils/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/jest-message-util": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
+			"integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.27.1",
+				"@jest/types": "30.4.1",
+				"@types/stack-utils": "^2.0.3",
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
+				"jest-util": "30.4.1",
+				"picomatch": "^4.0.3",
+				"pretty-format": "30.4.1",
+				"slash": "^3.0.0",
+				"stack-utils": "^2.0.6"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-message-util/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/jest-message-util/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/jest-message-util/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/jest-message-util/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/jest-message-util/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/jest-message-util/node_modules/picomatch": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+			"integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/jest-message-util/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/jest-mock": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
+			"integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.4.1",
+				"@types/node": "*",
+				"jest-util": "30.4.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-regex-util": {
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
+			"integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-util": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
+			"integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.4.1",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"graceful-fs": "^4.2.11",
+				"picomatch": "^4.0.3"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-util/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/jest-util/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/jest-util/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/jest-util/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/jest-util/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/jest-util/node_modules/picomatch": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+			"integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/jest-util/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -4452,10 +5130,20 @@
 			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+			"integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
 			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/puzrin"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodeca"
+				}
+			],
 			"license": "MIT",
 			"dependencies": {
 				"argparse": "^2.0.1"
@@ -5007,13 +5695,13 @@
 			}
 		},
 		"node_modules/minimatch": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"brace-expansion": "^2.0.1"
+				"brace-expansion": "^2.0.2"
 			},
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
@@ -5199,9 +5887,9 @@
 			}
 		},
 		"node_modules/mocha/node_modules/minimatch": {
-			"version": "5.1.6",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-			"integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+			"version": "5.1.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+			"integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -5794,9 +6482,9 @@
 			"license": "ISC"
 		},
 		"node_modules/path-to-regexp": {
-			"version": "8.3.0",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-			"integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+			"version": "8.4.2",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+			"integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -5851,9 +6539,9 @@
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -5899,6 +6587,35 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/pretty-format": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+			"integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/schemas": "30.4.1",
+				"ansi-styles": "^5.2.0",
+				"react-is-18": "npm:react-is@^18.3.1",
+				"react-is-19": "npm:react-is@^19.2.5"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/pretty-format/node_modules/ansi-styles": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
 		"node_modules/prismjs": {
@@ -5964,13 +6681,14 @@
 			}
 		},
 		"node_modules/qs": {
-			"version": "6.14.2",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-			"integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+			"version": "6.15.3",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+			"integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
-				"side-channel": "^1.1.0"
+				"es-define-property": "^1.0.1",
+				"side-channel": "^1.1.1"
 			},
 			"engines": {
 				"node": ">=0.6"
@@ -6037,6 +6755,22 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/react-is-18": {
+			"name": "react-is",
+			"version": "18.3.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+			"integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/react-is-19": {
+			"name": "react-is",
+			"version": "19.2.7",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
+			"integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/read": {
 			"version": "1.0.7",
@@ -6174,9 +6908,9 @@
 			}
 		},
 		"node_modules/rimraf/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.16",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6207,9 +6941,9 @@
 			}
 		},
 		"node_modules/rimraf/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -6347,15 +7081,15 @@
 			}
 		},
 		"node_modules/side-channel": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-			"integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+			"integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0",
-				"object-inspect": "^1.13.3",
-				"side-channel-list": "^1.0.0",
+				"object-inspect": "^1.13.4",
+				"side-channel-list": "^1.0.1",
 				"side-channel-map": "^1.0.1",
 				"side-channel-weakmap": "^1.0.2"
 			},
@@ -6367,14 +7101,14 @@
 			}
 		},
 		"node_modules/side-channel-list": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-			"integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+			"integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0",
-				"object-inspect": "^1.13.3"
+				"object-inspect": "^1.13.4"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -6564,6 +7298,29 @@
 			"integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
 			"dev": true,
 			"license": "BSD-3-Clause"
+		},
+		"node_modules/stack-utils": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+			"integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"escape-string-regexp": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/stack-utils/node_modules/escape-string-regexp": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+			"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
 		},
 		"node_modules/stdin-discarder": {
 			"version": "0.2.2",
@@ -6840,9 +7597,9 @@
 			}
 		},
 		"node_modules/test-exclude/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.16",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6873,9 +7630,9 @@
 			}
 		},
 		"node_modules/test-exclude/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -6899,9 +7656,9 @@
 			"license": "MIT"
 		},
 		"node_modules/tmp": {
-			"version": "0.2.5",
-			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-			"integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+			"version": "0.2.7",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+			"integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -7039,9 +7796,9 @@
 			}
 		},
 		"node_modules/tslint/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.16",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7089,9 +7846,9 @@
 			}
 		},
 		"node_modules/tslint/node_modules/js-yaml": {
-			"version": "3.14.2",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-			"integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+			"version": "3.15.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+			"integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7103,9 +7860,9 @@
 			}
 		},
 		"node_modules/tslint/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -7262,16 +8019,16 @@
 			"license": "MIT"
 		},
 		"node_modules/underscore": {
-			"version": "1.13.7",
-			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
-			"integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
+			"version": "1.13.8",
+			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+			"integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/undici": {
-			"version": "7.19.2",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.19.2.tgz",
-			"integrity": "sha512-4VQSpGEGsWzk0VYxyB/wVX/Q7qf9t5znLRgs0dzszr9w9Fej/8RVNQ+S20vdXSAyra/bJ7ZQfGv6ZMj7UEbzSg==",
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+			"integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -7308,16 +8065,6 @@
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/uuid": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"uuid": "dist/bin/uuid"
-			}
 		},
 		"node_modules/v8-compile-cache-lib": {
 			"version": "3.0.1",
@@ -7376,9 +8123,9 @@
 			}
 		},
 		"node_modules/vscode-languageclient/node_modules/minimatch": {
-			"version": "5.1.6",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-			"integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+			"version": "5.1.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+			"integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
 			"license": "ISC",
 			"dependencies": {
 				"brace-expansion": "^2.0.1"
@@ -7617,9 +8364,9 @@
 			"license": "ISC"
 		},
 		"node_modules/ws": {
-			"version": "8.19.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-			"integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+			"version": "8.21.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+			"integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	"description": "Tools for game development with Godot Engine and GDScript",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/godotengine/godot-vscode-plugin"
+		"url": "git+https://github.com/godotengine/godot-vscode-plugin.git"
 	},
 	"bugs": {
 		"url": "https://github.com/godotengine/godot-vscode-plugin/issues"
@@ -315,6 +315,31 @@
 					"default": "1",
 					"description": "Number of spaces before an end-of-line comment"
 				},
+                "godotTools.formatter.indentSize": {
+                    "type": "number",
+                    "default": 4,
+                    "description": "The size of the indentation (number of spaces). Only applies if 'Use Spaces' is true."
+                },
+                "godotTools.formatter.insertSpaces": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Use spaces for indentation instead of tabs."
+                },
+                "godotTools.formatter.trimEmptyLines": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Remove whitespace characters (spaces/tabs) from empty lines, keeping the line count intact."
+                },
+				"godotTools.formatter.enforceNewlineAfterControlFlow": {
+					"type": "boolean",
+					"default": true,
+					"description": "Force a newline after the colon in single-line control flow statements (like if, for, while, match) and single-line function declarations"
+				},
+                "godotTools.formatter.enforceNewlineAfterMatchBranch": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Force a newline after the colon in match branch patterns."
+                },
 				"godotTools.lsp.serverHost": {
 					"type": "string",
 					"default": "127.0.0.1",
@@ -888,12 +913,13 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^1.9.4",
-		"@types/chai": "^4.3.11",
+		"@types/chai": "^4.3.20",
 		"@types/chai-as-promised": "^8.0.1",
 		"@types/chai-subset": "^1.3.5",
+		"@types/jest": "^30.0.0",
 		"@types/marked": "^4.0.8",
-		"@types/mocha": "^10.0.6",
-		"@types/node": "^18.19.75",
+		"@types/mocha": "^10.0.10",
+		"@types/node": "^18.19.130",
 		"@types/prismjs": "^1.16.8",
 		"@types/sinon": "^17.0.4",
 		"@types/vscode": "^1.96.0",
@@ -928,8 +954,11 @@
 		"terminate": "^2.5.0",
 		"vscode-languageclient": "^9.0.1",
 		"vscode-oniguruma": "^2.0.1",
-		"vscode-textmate": "^9.0.0",
+		"vscode-textmate": "^9.3.2",
 		"ws": "^8.17.1",
 		"ya-bbcode": "^4.0.0"
-	}
+	},
+	"keywords": [],
+	"type": "commonjs",
+	"homepage": "https://github.com/godotengine/godot-vscode-plugin#readme"
 }

--- a/src/formatter/formatter.test.ts
+++ b/src/formatter/formatter.test.ts
@@ -5,6 +5,7 @@ import * as vscode from "vscode";
 import { format_document, type FormatterOptions } from "./textmate";
 
 import { expect } from "chai";
+import { suite, test, teardown } from "mocha";
 
 const dots = ["..", "..", ".."];
 const basePath = path.join(__filename, ...dots);
@@ -18,6 +19,11 @@ const defaultOptions: FormatterOptions = {
 	maxEmptyLines: 2,
 	denseFunctionParameters: false,
 	spacesBeforeEndOfLineComment: 1,
+    indentSize: 4,
+    insertSpaces: false,
+    trimEmptyLines: true,
+	enforceNewlineAfterControlFlow: true,
+	enforceNewlineAfterMatchBranch: true,
 };
 
 function set_content(content: string) {
@@ -52,7 +58,11 @@ class TestLines {
 	out: string[] = [];
 
 	parse(_config) {
-		const config = { ...defaultOptions, ..._config, ...build_config(this.config) };
+		const config = {
+			...defaultOptions,
+			..._config,
+			...build_config(this.config),
+		};
 
 		const test: Test = {
 			in: this.in.join("\n"),
@@ -127,7 +137,10 @@ function parse_test_file(content: string): Test[] {
 }
 
 suite("GDScript Formatter Tests", () => {
-	const testFiles = fs.readdirSync(snapshotsFolderPath, { withFileTypes: true, recursive: true });
+	const testFiles = fs.readdirSync(snapshotsFolderPath, {
+		withFileTypes: true,
+		recursive: true,
+	});
 
 	teardown(async () => {
 		await vscode.commands.executeCommand("workbench.action.closeAllEditors");
@@ -159,5 +172,4 @@ suite("GDScript Formatter Tests", () => {
 			}
 		});
 	}
-
 });

--- a/src/formatter/formatter.ts
+++ b/src/formatter/formatter.ts
@@ -4,7 +4,9 @@ import { createLogger } from "../utils";
 
 const log = createLogger("formatter");
 
-export class FormattingProvider implements vscode.DocumentFormattingEditProvider {
+export class FormattingProvider
+	implements vscode.DocumentFormattingEditProvider
+{
 	constructor(private context: vscode.ExtensionContext) {
 		const selector = { language: "gdscript", scheme: "file" };
 

--- a/src/formatter/index.ts
+++ b/src/formatter/index.ts
@@ -1,1 +1,1 @@
-export * from "./formatter";	
+export * from "./formatter";

--- a/src/formatter/symbols.ts
+++ b/src/formatter/symbols.ts
@@ -1,4 +1,3 @@
-
 export const keywords = [
 	"and",
 	"as",

--- a/src/formatter/textmate.ts
+++ b/src/formatter/textmate.ts
@@ -4,27 +4,36 @@ import * as fs from "node:fs";
 import * as vsctm from "vscode-textmate";
 import * as oniguruma from "vscode-oniguruma";
 import { keywords, symbols } from "./symbols";
-import { get_configuration, get_extension_uri, createLogger, is_debug_mode } from "../utils";
+import {
+	get_configuration,
+	get_extension_uri,
+	createLogger,
+	is_debug_mode,
+} from "../utils";
 import { readFile } from "node:fs/promises";
 
 const log = createLogger("formatter.tm");
 
-const grammarPath = get_extension_uri("syntaxes/GDScript.tmLanguage.json").fsPath;
+const grammarPath = get_extension_uri(
+	"syntaxes/GDScript.tmLanguage.json",
+).fsPath;
 const wasmPath = get_extension_uri("resources/onig.wasm").fsPath;
 const wasmBin = fs.readFileSync(wasmPath).buffer;
 
 // Create a registry that can create a grammar from a scope name.
 const registry = new vsctm.Registry({
-	onigLib: oniguruma.loadWASM(wasmBin as unknown as oniguruma.IOptions).then(() => {
-		return {
-			createOnigScanner(patterns) {
-				return new oniguruma.OnigScanner(patterns);
-			},
-			createOnigString(s) {
-				return new oniguruma.OnigString(s);
-			},
-		};
-	}),
+	onigLib: oniguruma
+		.loadWASM(wasmBin as unknown as oniguruma.IOptions)
+		.then(() => {
+			return {
+				createOnigScanner(patterns) {
+					return new oniguruma.OnigScanner(patterns);
+				},
+				createOnigString(s) {
+					return new oniguruma.OnigString(s);
+				},
+			};
+		}),
 	loadGrammar: async (scopeName) => {
 		if (scopeName === "source.gdscript") {
 			const data = await readFile(grammarPath);
@@ -53,16 +62,36 @@ export interface FormatterOptions {
 	maxEmptyLines: number;
 	denseFunctionParameters: boolean;
 	spacesBeforeEndOfLineComment: 1 | 2;
+	indentSize: number;
+	insertSpaces: boolean;
+	trimEmptyLines: boolean;
+	enforceNewlineAfterControlFlow: boolean;
+	enforceNewlineAfterMatchBranch: boolean;
 }
 
 function get_formatter_options() {
 	const rawMaxEmptyLines = get_configuration("formatter.maxEmptyLines");
-	const maxEmptyLines = typeof rawMaxEmptyLines === "number" ? Math.max(0, Math.round(rawMaxEmptyLines)) : 2;
+	const maxEmptyLines =
+		typeof rawMaxEmptyLines === "number"
+			? Math.max(0, Math.round(rawMaxEmptyLines))
+			: 2;
 
 	const options: FormatterOptions = {
 		maxEmptyLines: maxEmptyLines,
-		denseFunctionParameters: get_configuration("formatter.denseFunctionParameters"),
-		spacesBeforeEndOfLineComment: get_configuration("formatter.spacesBeforeEndOfLineComment") === "1" ? 1 : 2,
+		denseFunctionParameters: get_configuration(
+			"formatter.denseFunctionParameters",
+		),
+		spacesBeforeEndOfLineComment:
+			get_configuration("formatter.spacesBeforeEndOfLineComment") === "1"
+				? 1
+				: 2,
+		indentSize: get_configuration("formatter.indentSize") ?? 4,
+		insertSpaces: get_configuration("formatter.insertSpaces") ?? false,
+		trimEmptyLines: get_configuration("formatter.trimEmptyLines") ?? true,
+		enforceNewlineAfterControlFlow:
+			get_configuration("formatter.enforceNewlineAfterControlFlow") ?? true,
+		enforceNewlineAfterMatchBranch:
+			get_configuration("formatter.enforceNewlineAfterMatchBranch") ?? false,
 	};
 
 	return options;
@@ -132,7 +161,10 @@ function parse_token(token: Token) {
 		token.type = "keyword";
 		return;
 	}
-	if (token.scopes.includes("constant.language.gdscript") || token.scopes.includes("constant.language.literal.gdscript")) {
+	if (
+		token.scopes.includes("constant.language.gdscript") ||
+		token.scopes.includes("constant.language.literal.gdscript")
+	) {
 		token.type = "constant";
 		return;
 	}
@@ -156,8 +188,10 @@ function between(tokens: Token[], current: number, options: FormatterOptions) {
 
 	if (!prev) return "";
 
-	if (next === "##") return options.spacesBeforeEndOfLineComment === 2 ? "  " : " ";
-	if (next === "#") return options.spacesBeforeEndOfLineComment === 2 ? "  " : " ";
+	if (next === "##")
+		return options.spacesBeforeEndOfLineComment === 2 ? "  " : " ";
+	if (next === "#")
+		return options.spacesBeforeEndOfLineComment === 2 ? "  " : " ";
 	if (prevToken.skip && nextToken.skip) return "";
 
 	if (prev === "(") return "";
@@ -167,7 +201,7 @@ function between(tokens: Token[], current: number, options: FormatterOptions) {
 	}
 	if (next === ".") return "";
 
-	if (nextToken.param && !nextToken.inLambdaBody && !(prevToken?.inLambdaBody)) {
+	if (nextToken.param && !nextToken.inLambdaBody && !prevToken?.inLambdaBody) {
 		if (options.denseFunctionParameters) {
 			if (prev === "-" || prev === "+") {
 				if (tokens[current - 2]?.value === "=") return "";
@@ -270,28 +304,64 @@ function is_comment(line: TextLine): boolean {
 
 function is_merge_conflict_marker(line: TextLine): boolean {
 	const trimmed = line.text.trimStart();
-	return trimmed.startsWith("<<<<<<<") || trimmed.startsWith("=======") || trimmed.startsWith(">>>>>>>");
+	return (
+		trimmed.startsWith("<<<<<<<") ||
+		trimmed.startsWith("=======") ||
+		trimmed.startsWith(">>>>>>>")
+	);
 }
 
-export function format_document(document: TextDocument, _options?: FormatterOptions): TextEdit[] {
+export function format_document(
+	document: TextDocument,
+	_options?: FormatterOptions,
+): TextEdit[] {
 	// quit early if grammar is not loaded
 	if (!grammar) {
 		return [];
 	}
+
 	const edits: TextEdit[] = [];
 
 	const options = _options ?? get_formatter_options();
 
+	const blockKeywords = [
+		"if",
+		"elif",
+		"else",
+		"for",
+		"while",
+		"match",
+		"when",
+		"func",
+	];
+
 	let lastToken = "";
+	let indentLevel = 0;
 	let lineTokens: vsctm.ITokenizeLineResult | undefined = undefined;
 	let onlyEmptyLinesSoFar = true;
 	let emptyLineCount = 0;
 	let inLambdaBody = false;
+
+	// Utility function: Generate indentation string for specified level
+	const make_indent = (level: number): string => {
+		if (options.insertSpaces) {
+			return " ".repeat(level * options.indentSize);
+		} else {
+			return "\t".repeat(level);
+		}
+	};
+
 	for (let lineNum = 0; lineNum < document.lineCount; lineNum++) {
 		const line = document.lineAt(lineNum);
 
 		// skip empty lines
 		if (line.isEmptyOrWhitespace) {
+			// If there are whitespace characters (like spaces or tabs) within the line
+			// and the configuration is set to clean, then clear the content.
+			if (line.text.length > 0 && options.trimEmptyLines) {
+				edits.push(TextEdit.replace(line.range, ""));
+			}
+
 			// delete empty lines at the beginning of the file
 			if (onlyEmptyLinesSoFar) {
 				edits.push(TextEdit.delete(line.rangeIncludingLineBreak));
@@ -301,12 +371,19 @@ export function format_document(document: TextDocument, _options?: FormatterOpti
 
 			// delete empty lines at the end of the file
 			if (lineNum === document.lineCount - 1) {
-				for (let i = lineNum - emptyLineCount + 1; i < document.lineCount; i++) {
-					edits.push(TextEdit.delete(document.lineAt(i).rangeIncludingLineBreak));
+				for (
+					let i = lineNum - emptyLineCount + 1;
+					i < document.lineCount;
+					i++
+				) {
+					edits.push(
+						TextEdit.delete(document.lineAt(i).rangeIncludingLineBreak),
+					);
 				}
 			}
 			continue;
 		}
+
 		onlyEmptyLinesSoFar = false;
 
 		// delete consecutive empty lines
@@ -316,7 +393,9 @@ export function format_document(document: TextDocument, _options?: FormatterOpti
 				maxEmptyLines = 0;
 			}
 			for (let i = emptyLineCount - maxEmptyLines; i > 0; i--) {
-				edits.push(TextEdit.delete(document.lineAt(lineNum - i).rangeIncludingLineBreak));
+				edits.push(
+					TextEdit.delete(document.lineAt(lineNum - i).rangeIncludingLineBreak),
+				);
 			}
 			emptyLineCount = 0;
 		}
@@ -332,11 +411,34 @@ export function format_document(document: TextDocument, _options?: FormatterOpti
 		}
 
 		let nextLine = "";
-		lineTokens = grammar.tokenizeLine(line.text, lineTokens?.ruleStack ?? vsctm.INITIAL);
+		lineTokens = grammar.tokenizeLine(
+			line.text,
+			lineTokens?.ruleStack ?? vsctm.INITIAL,
+		);
 
-		// TODO: detect whitespace type and automatically convert
-		const leadingWhitespace = line.text.slice(0, line.firstNonWhitespaceCharacterIndex);
-		nextLine += leadingWhitespace;
+		// detect whitespace type and automatically convert
+		const leadingWhitespace = line.text.slice(
+			0,
+			line.firstNonWhitespaceCharacterIndex,
+		);
+
+		// Count tabs and spaces separately, then calculate the actual logical indentation level.
+		let tabs = 0;
+		let spaces = 0;
+		for (const ch of leadingWhitespace) {
+			if (ch === "\t") {
+				tabs++;
+			} else if (ch === " ") {
+				spaces++;
+			}
+		}
+		indentLevel = tabs + Math.floor(spaces / options.indentSize);
+
+		if (indentLevel < 0) indentLevel = 0;
+
+		// Apply the calculated indentation
+		nextLine += make_indent(indentLevel);
+
 		const first = lineTokens.tokens[0];
 		if (line.text.slice(first.startIndex, first.endIndex).trim() === "") {
 			lineTokens.tokens.shift();
@@ -350,6 +452,7 @@ export function format_document(document: TextDocument, _options?: FormatterOpti
 				value: line.text.slice(t.startIndex, t.endIndex).trim(),
 			};
 			parse_token(token);
+
 			// skip whitespace tokens
 			if (!token.string && token.value.trim() === "") {
 				continue;
@@ -381,10 +484,19 @@ export function format_document(document: TextDocument, _options?: FormatterOpti
 				tokens[i].inLambdaBody = true;
 			}
 		}
+
+		let bracketDepth = 0;
+		let forceNewLine = false;
+
 		for (let i = 0; i < tokens.length; i++) {
 			if (is_debug_mode()) log.debug(i, tokens[i].value, tokens[i]);
 
-			if (i === 0 && tokens[i].string) {
+			if (forceNewLine) {
+				indentLevel++;
+				nextLine += `\n${make_indent(indentLevel)}`;
+				nextLine += tokens[i].value.trim();
+				forceNewLine = false;
+			} else if (i === 0 && tokens[i].string) {
 				// leading whitespace is already accounted for
 				nextLine += tokens[i].original.trimStart();
 			} else if (i > 0 && tokens[i - 1].string && tokens[i].string) {
@@ -392,6 +504,80 @@ export function format_document(document: TextDocument, _options?: FormatterOpti
 			} else {
 				nextLine += between(tokens, i, options) + tokens[i].value.trim();
 			}
+
+			// Track parenthesis depth, skip dictionaries `{"a": 1}` and type annotations `func(a: int)`
+			if (
+				tokens[i].value === "(" ||
+				tokens[i].value === "[" ||
+				tokens[i].value === "{"
+			) {
+				bracketDepth++;
+			} else if (
+				tokens[i].value === ")" ||
+				tokens[i].value === "]" ||
+				tokens[i].value === "}"
+			) {
+				bracketDepth--;
+			}
+
+			// Detect control flow colon and trigger forced line break
+            if (options.enforceNewlineAfterControlFlow && i < tokens.length - 1) {
+                if (tokens[i].value === ":" && bracketDepth === 0) {
+
+                    // Search forward for var/const
+                    let hasVarOrConst = false;
+                    for (let j = i - 1; j >= 0; j--) {
+                        if (tokens[j].value === "var" || tokens[j].value === "const") {
+                            hasVarOrConst = true;
+                            break;
+                        }
+                    }
+
+                    // Check what's after the colon.
+                    let isTypeAnnotation = false;
+                    if (i + 1 < tokens.length) {
+                        const nextToken = tokens[i + 1];
+                        if (nextToken.identifier || nextToken.value === "=") {
+                            isTypeAnnotation = true;
+                        }
+                    }
+
+                    if (hasVarOrConst) {
+                        if (isTypeAnnotation) {
+                            // 'var x: int' 或 'var x: = 1' ( Variable definition)
+                            // => No newline
+                        } else {
+                            // 'var y:' ( Match mode variables)
+                            // => Newline
+                            forceNewLine = true;
+                        }
+                    } else {
+                        let hasControlFlow = false;
+                        for (let j = 0; j <= i; j++) {
+                            if (blockKeywords.includes(tokens[j].value)) {
+                                hasControlFlow = true;
+                                break;
+                            }
+                        }
+
+                        if (hasControlFlow) {
+                            // 'if x:', 'match x:', 'func():'
+                            // => Control flow, newline
+                            forceNewLine = true;
+                        } else if (isTypeAnnotation) {
+                            // Function parameter: 'param: Type'
+                            // => Type annotations, no newline
+                        } else if (options.enforceNewlineAfterMatchBranch) {
+                            const isIndented = leadingWhitespace.length > 0;
+                            if (isIndented) {
+                                forceNewLine = true;
+                            }
+                        }
+                    }
+                }
+            }
+
+
 			if (tokens[i].type !== "comment") {
 				lastToken = tokens[i].value;
 			}

--- a/src/formatter/textmate.ts
+++ b/src/formatter/textmate.ts
@@ -521,62 +521,73 @@ export function format_document(
 			}
 
 			// Detect control flow colon and trigger forced line break
-            if (options.enforceNewlineAfterControlFlow && i < tokens.length - 1) {
-                if (tokens[i].value === ":" && bracketDepth === 0) {
+			if (options.enforceNewlineAfterControlFlow && i < tokens.length - 1) {
+				if (tokens[i].value === ":" && bracketDepth === 0) {
+					// If the current colon is inside a function parameter scope,
+					// skip the newline logic directly.
+					if (tokens[i].param) {
+						continue;
+					}
 
-                    // Search forward for var/const
-                    let hasVarOrConst = false;
-                    for (let j = i - 1; j >= 0; j--) {
-                        if (tokens[j].value === "var" || tokens[j].value === "const") {
-                            hasVarOrConst = true;
-                            break;
-                        }
-                    }
+					// Search forward for var/const
+					let hasVarOrConst = false;
+					for (let j = i - 1; j >= 0; j--) {
+						if (tokens[j].value === "var" || tokens[j].value === "const") {
+							hasVarOrConst = true;
+							break;
+						}
+					}
 
-                    // Check what's after the colon.
-                    let isTypeAnnotation = false;
-                    if (i + 1 < tokens.length) {
-                        const nextToken = tokens[i + 1];
-                        if (nextToken.identifier || nextToken.value === "=") {
-                            isTypeAnnotation = true;
-                        }
-                    }
+					// Check what's after the colon.
+					const hasFollowingToken = i + 1 < tokens.length;
 
-                    if (hasVarOrConst) {
-                        if (isTypeAnnotation) {
-                            // 'var x: int' 或 'var x: = 1' ( Variable definition)
-                            // => No newline
-                        } else {
-                            // 'var y:' ( Match mode variables)
-                            // => Newline
-                            forceNewLine = true;
-                        }
-                    } else {
-                        let hasControlFlow = false;
-                        for (let j = 0; j <= i; j++) {
-                            if (blockKeywords.includes(tokens[j].value)) {
-                                hasControlFlow = true;
-                                break;
-                            }
-                        }
+					if (hasVarOrConst) {
+						//! Case A: Found it, var/const
+						if (hasFollowingToken) {
+							// 'var x: int' 或 'var x: = 1' ( Variable definition)
+							// => No newline
+						} else {
+							// 'var y:' ( Match mode variables)
+							// => Newline
+							forceNewLine = true;
+						}
+					} else {
+						//! Case B: No var/const
+						let hasControlFlow = false;
+						for (let j = 0; j <= i; j++) {
+							if (blockKeywords.includes(tokens[j].value)) {
+								hasControlFlow = true;
+								break;
+							}
+						}
 
-                        if (hasControlFlow) {
-                            // 'if x:', 'match x:', 'func():'
-                            // => Control flow, newline
-                            forceNewLine = true;
-                        } else if (isTypeAnnotation) {
-                            // Function parameter: 'param: Type'
-                            // => Type annotations, no newline
-                        } else if (options.enforceNewlineAfterMatchBranch) {
-                            const isIndented = leadingWhitespace.length > 0;
-                            if (isIndented) {
-                                forceNewLine = true;
-                            }
-                        }
-                    }
-                }
-            }
-
+						if (hasControlFlow) {
+							// 'if x:', 'match x:', 'func():' (Control flow)
+							// => newline
+							forceNewLine = true;
+						} else if (hasFollowingToken) {
+							//! Case C: There are subsequent tokens, but no control flow keywords.
+							// This might be a match branch pattern
+							// (e.g., `StatOverType.EQUAL: str_over_type = "="`)
+							//  If it's indented, force a line break.
+							// Note: Colons in dictionary {key: value}
+							// are protected by bracketDepth and won't enter this branch.
+							const isIndented = leadingWhitespace.length > 0;
+							if (isIndented) {
+								forceNewLine = true;
+							}
+						} else {
+							//! Case D: No follow-up tokens, no control flow keywords either.
+							if (options.enforceNewlineAfterMatchBranch) {
+								const isIndented = leadingWhitespace.length > 0;
+								if (isIndented) {
+									forceNewLine = true;
+								}
+							}
+						}
+					}
+				}
+			}
 
 			if (tokens[i].type !== "comment") {
 				lastToken = tokens[i].value;

--- a/test_projects/test-dap-project-godot4/ControlFlow.gd
+++ b/test_projects/test-dap-project-godot4/ControlFlow.gd
@@ -1,0 +1,57 @@
+extends Node
+class_name ControlFlow
+
+# Testing If-Else Chain
+if x > 0:print("positive")
+elif x < 0:print("negative")
+else:print("zero")
+
+# Single-line if and ternary expression
+if check():run()
+var result = 10 if is_ready else 0
+
+# Test for and while loops
+for i in range(10): print(i)
+for item in items:process(item)
+while x > 0:x -= 1
+
+# Test nested control flow indentation.
+func test():
+    if true:for i in 3:print(i)
+    if false: match x: 1: pass
+
+# Match vs. dictionary literal
+var dict = {"key": "value"}
+match dict:
+    {"key": "value"}: print("matched")
+
+# Test basic Match branch (no space after colon)
+match role:
+    "admin":access_level=10
+    "moderator","editor":access_level=5
+    var matched_role when matched_role.begins_with("user"):access_level=1
+    _:access_level=0
+
+# Test Match branch with complex expressions and line breaks.
+match state:
+    "idle": start_timer()
+    "running": 
+        update_position()
+        check_collisions()
+    "jumping": velocity.y = jump_force
+
+# Test nested Match and dictionary matching conflicts.
+match x:
+    0:
+        match y:
+            1: pass
+            2: pass
+    {"key": "value"}: print("dict pattern")
+    []: print("array pattern")
+
+# Test multi-value matching with pattern guards.
+match x:
+    1, 2, 3: print("small")
+    var n when n > 10: print("big")
+    var n when n < 0: print("negative")
+    _: print("other")


### PR DESCRIPTION
- Bump vscode-textmate to ^9.3.2 and ws to ^8.21.1.
- Update @types packages and various transitive dependencies.
- Remove uuid dependency from @azure/msal-node.
- Add @types/jest and jest-related packages.

chore(formatter): Add enforce newline after control flow option.

- Add `enforceNewlineAfterControlFlow` to FormatterOptions and configuration.
- Implement forced line break after colons in single-line control flow statements.
- Update tests and snapshots to cover new formatting behavior.
- Minor formatting and style cleanups in formatter source files.

feat(formatter): Add `enforceNewlineAfterMatchBranch` option.

- Add new `enforceNewlineAfterMatchBranch` boolean option to `FormatterOptions`.
- Implement heuristic to enforce newline after match branch colons when enabled.
- Update tests to include the new option in default options.
- Bump `@types/vscode` dev dependency from `^1.125.0` to `^1.96.0`.

feat(formatter): Add configurable indentation and empty line trimming options.

- Add `indentSize`, `insertSpaces`, and `trimEmptyLines` configuration options to `package.json`.
- Extend `FormatterOptions` interface with new indentation and trimming fields.
- Implement `make_indent` utility to generate indentation strings based on settings.
- Apply configurable indentation when formatting lines instead of preserving raw whitespace.
- Add logic to strip whitespace from empty lines when `trimEmptyLines` is enabled.
- Update test defaults to include new formatter options.

style(textmate): Normalize indentation from spaces to tabs across formatter

- Convert all remaining 4-space indents to tabs for consistency with project style
- Update `FormatterOptions` interface and `get_formatter_options` function
- Adjust `format_document` local variables, `make_indent` utility, and empty-line handling block