### PR TITLE
Add optional Godot editor terminal reuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ You can use the following settings to configure Godot Tools:
 
 The path to the Godot editor executable. _Under Mac OS, this is the executable inside of Godot.app._
 
+- `godotTools.editor.reuseTerminal`
+
+Reuse the existing Godot Editor terminal when relaunching the editor, preserving its location and layout.
+
 - `godotTools.lsp.headless`
 
 When using Godot >3.6 or >4.2, Headless LSP mode is available. In Headless mode, the extension will attempt to launch a windowless instance of the Godot editor to use as its Language Server.

--- a/package.json
+++ b/package.json
@@ -291,6 +291,11 @@
 					"default": true,
 					"description": "Whether to reveal the terminal when launching the Godot Editor"
 				},
+				"godotTools.editor.reuseTerminal": {
+					"type": "boolean",
+					"default": false,
+					"description": "Whether to reuse the existing Godot Editor terminal when relaunching the editor"
+				},
 				"godotTools.formatter.maxEmptyLines": {
 					"type": "number",
 					"default": 2,

--- a/src/editor_terminal.test.ts
+++ b/src/editor_terminal.test.ts
@@ -1,0 +1,118 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as vscode from "vscode";
+import { expect } from "chai";
+
+const TERMINAL_NAME = "Godot Editor";
+
+function waitFor<T>(getValue: () => T | undefined, timeout = 5000): Promise<T> {
+	return new Promise((resolve, reject) => {
+		const started = Date.now();
+		const interval = setInterval(() => {
+			const value = getValue();
+			if (value !== undefined) {
+				clearInterval(interval);
+				resolve(value);
+			} else if (Date.now() - started >= timeout) {
+				clearInterval(interval);
+				reject(new Error("Timed out waiting for Godot Editor terminal state"));
+			}
+		}, 25);
+	});
+}
+
+function createFakeGodot(directory: string, launchLog: string): string {
+	if (process.platform === "win32") {
+		const executable = path.join(directory, "fake-godot.cmd");
+		fs.writeFileSync(
+			executable,
+			[
+				"@echo off",
+				'if "%~1"=="--version" (',
+				"  echo 4.5.1.stable",
+				"  exit /b 0",
+				")",
+				`echo launch>>"${launchLog}"`,
+			].join("\r\n"),
+		);
+		return executable;
+	}
+
+	const executable = path.join(directory, "fake-godot");
+	fs.writeFileSync(
+		executable,
+		[
+			"#!/bin/sh",
+			'if [ "$1" = "--version" ]; then',
+			"  printf '4.5.1.stable\\n'",
+			"  exit 0",
+			"fi",
+			`printf 'launch\\n' >> '${launchLog}'`,
+		].join("\n"),
+	);
+	fs.chmodSync(executable, 0o755);
+	return executable;
+}
+
+suite("Godot Editor terminal", () => {
+	const configuration = vscode.workspace.getConfiguration("godotTools");
+	const workspaceDirectory = vscode.workspace.workspaceFolders?.[0].uri.fsPath;
+	let tempDirectory: string;
+	let settingsFile: string;
+	let originalSettings: Buffer | undefined;
+
+	setup(async () => {
+		if (!workspaceDirectory) {
+			throw new Error("Test workspace is unavailable");
+		}
+		settingsFile = path.join(workspaceDirectory, ".vscode", "settings.json");
+		originalSettings = fs.existsSync(settingsFile) ? fs.readFileSync(settingsFile) : undefined;
+		tempDirectory = fs.mkdtempSync(path.join(workspaceDirectory, ".godot-terminal-test-"));
+		await configuration.update(
+			"editorPath.godot4",
+			createFakeGodot(tempDirectory, path.join(tempDirectory, "launches.log")),
+			vscode.ConfigurationTarget.Workspace,
+		);
+		await configuration.update("editor.reuseTerminal", true, vscode.ConfigurationTarget.Workspace);
+		await configuration.update("editor.revealTerminal", false, vscode.ConfigurationTarget.Workspace);
+	});
+
+	teardown(async () => {
+		for (const terminal of vscode.window.terminals.filter((terminal) => terminal.name === TERMINAL_NAME)) {
+			terminal.dispose();
+		}
+		await configuration.update("editorPath.godot4", undefined, vscode.ConfigurationTarget.Workspace);
+		await configuration.update("editor.reuseTerminal", undefined, vscode.ConfigurationTarget.Workspace);
+		await configuration.update("editor.revealTerminal", undefined, vscode.ConfigurationTarget.Workspace);
+		if (originalSettings) {
+			fs.writeFileSync(settingsFile, originalSettings);
+		} else {
+			fs.rmSync(settingsFile, { force: true });
+		}
+		fs.rmSync(tempDirectory, { recursive: true, force: true });
+	});
+
+	test("reuses a terminal after it is moved into the editor area", async function () {
+		this.timeout(10_000);
+		const launchLog = path.join(tempDirectory, "launches.log");
+		const findTerminal = () => vscode.window.terminals.find((terminal) => terminal.name === TERMINAL_NAME);
+		const findTab = () =>
+			vscode.window.tabGroups.all
+				.flatMap((group) => group.tabs)
+				.find((tab) => tab.input instanceof vscode.TabInputTerminal && tab.label === TERMINAL_NAME);
+
+		await vscode.commands.executeCommand("godotTools.openEditor");
+		const terminal = await waitFor(findTerminal);
+		await waitFor(() => (fs.existsSync(launchLog) ? true : undefined));
+		terminal.show();
+		await vscode.commands.executeCommand("workbench.action.terminal.moveToEditor");
+		const tab = await waitFor(findTab);
+
+		await vscode.commands.executeCommand("godotTools.openEditor");
+		await waitFor(() => (fs.readFileSync(launchLog, "utf8").trim().split("\n").length === 2 ? true : undefined));
+
+		expect(findTerminal()).to.equal(terminal);
+		expect(findTab()).to.equal(tab);
+		expect(findTab()?.group).to.equal(tab.group);
+	});
+});

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -54,6 +54,9 @@ interface Extension {
 
 export const globals: Extension = {};
 
+let godotEditorTerminal: vscode.Terminal | undefined;
+let godotEditorPty: GodotEditorTerminal | undefined;
+
 export function activate(context: vscode.ExtensionContext) {
 	attemptSettingsUpdate(context);
 
@@ -192,15 +195,29 @@ async function open_workspace_with_editor() {
 			}
 			const existingTerminal = vscode.window.terminals.find((t) => t.name === "Godot Editor");
 			if (existingTerminal) {
+				if (
+					get_configuration("editor.reuseTerminal") &&
+					existingTerminal === godotEditorTerminal &&
+					godotEditorPty
+				) {
+					godotEditorPty.restart(command);
+					if (get_configuration("editor.revealTerminal")) {
+						existingTerminal.show();
+					}
+					break;
+				}
 				existingTerminal.dispose();
 			}
+			const pty = new GodotEditorTerminal(command);
 			const options: vscode.ExtensionTerminalOptions = {
 				name: "Godot Editor",
 				iconPath: get_extension_uri("resources/godot_icon.svg"),
-				pty: new GodotEditorTerminal(command),
+				pty,
 				isTransient: true,
 			};
 			const terminal = vscode.window.createTerminal(options);
+			godotEditorTerminal = terminal;
+			godotEditorPty = pty;
 			if (get_configuration("editor.revealTerminal")) {
 				terminal.show();
 			}
@@ -297,6 +314,12 @@ class GodotEditorTerminal implements vscode.Pseudoterminal {
 		proc.on("close", (code) => {
 			this.writeEmitter.fire(`Godot Editor stopped with exit code: ${code}\r\n`);
 		});
+	}
+
+	restart(command: string): void {
+		this.command = command;
+		killSubProcesses("GodotEditor");
+		this.open(undefined);
 	}
 
 	close(): void {

--- a/src/utils/subspawn.ts
+++ b/src/utils/subspawn.ts
@@ -60,6 +60,14 @@ export function subProcess(owner: string, command: string, options?: SpawnOption
 
 	children[owner] = children[owner] || [];
 	children[owner].push(childProcess);
+	const remove = () => {
+		const index = children[owner]?.indexOf(childProcess) ?? -1;
+		if (index >= 0) {
+			children[owner].splice(index, 1);
+		}
+	};
+	childProcess.once("exit", remove);
+	childProcess.once("error", remove);
 
 	return childProcess;
 }


### PR DESCRIPTION
This PR adds an option to reuse the existing Godot editor terminal rather than spawn a new one every time. I tend to move the terminal window out of the normal terminal space and into a tab in the code editing space, and it was killing me that my window arrangement would get messed up every time I needed to restart the editor for some reason.

Full disclosure, this was vibe coded by Codex 5.6 Sol. Absolutely zero hard feelings if you are auto closing vibe-coded PRs, I totally get it. But I thought I would go ahead and submit it because it looked like a pretty simple change, and I have found it to be a nice quality of life improvement, so I thought I would offer it up in case it would be of help to other folks, and since it didn't look too invasive or too sloppy.